### PR TITLE
Fix compilation when relying on clang which does not support msvc flags

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,13 +2,11 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.std("c11").include(src_dir);
+    c_config.std("c11").include(&src_dir);
+    c_config.flag_if_supported("-Wno-unused-parameter");
 
-    if cfg!(target_env = "msvc") {
-        c_config.flags(["/utf-8", "/wd4100"]);
-    } else {
-        c_config.flag("-Wno-unused-parameter");
-    }
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
 
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);


### PR DESCRIPTION
I am trying to compile this library to wasi and getting some issues, there are msvc flags with slash that are not recognised by clang which is used for compiling for wasi on windows via cc-rs crate, but build.rs script is compiled with target_env msvc, so we end up with msvc flags passed to clang which interpret them as file name and fail to find them.

Looks like its generated by python script, but it was already updated by hand, so I suppose this small change should do it. 

This compile fine for me on WASI.
